### PR TITLE
MQTTS support in the file-upload's local connection

### DIFF
--- a/client/edge.go
+++ b/client/edge.go
@@ -15,6 +15,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -30,12 +31,12 @@ const (
 
 // BrokerConfig contains address and credentials for the MQTT broker
 type BrokerConfig struct {
-	Broker     string `json:"broker,omitempty" def:"tcp://localhost:1883" descr:"Local MQTT broker address"`
-	Username   string `json:"username,omitempty" descr:"Username for authorized local client"`
-	Password   string `json:"password,omitempty" descr:"Password for authorized local client"`
-	CaCert     string `json:"caCert,omitempty" descr:"A PEM encoded certificate authority, used to sign the certificate of the local MQTT broker"`
-	DeviceCert string `json:"deviceCert,omitempty" descr:"A PEM encoded client certificate for connection to local MQTT broker"`
-	DeviceKey  string `json:"deviceKey,omitempty" descr:"А private key for the client certificate, specified with 'deviceCert'"`
+	Broker         string `json:"broker,omitempty" def:"tcp://localhost:1883" descr:"Local MQTT broker address"`
+	Username       string `json:"username,omitempty" descr:"Username for authorized local client"`
+	Password       string `json:"password,omitempty" descr:"Password for authorized local client"`
+	CaCertMQTT     string `json:"caCertMQTT,omitempty" descr:"A PEM encoded certificate authority, used to sign the certificate of the local MQTT broker"`
+	ClientCertMQTT string `json:"clientCertMQTT,omitempty" descr:"A PEM encoded client certificate for connection to local MQTT broker"`
+	ClientKeyMQTT  string `json:"clientKeyMQTT,omitempty" descr:"А private key for the client certificate, specified with 'deviceCert'"`
 }
 
 // EdgeConfiguration represents local Edge Thing configuration - its device, tenant and policy identifiers.
@@ -62,22 +63,22 @@ type EdgeClient interface {
 func NewEdgeConnector(cfg *BrokerConfig, ecl EdgeClient) (*EdgeConnector, error) {
 	var certificates []tls.Certificate
 	var caCertPool *x509.CertPool
-	if len(cfg.DeviceCert) > 0 {
-		keyPair, err := tls.LoadX509KeyPair(cfg.DeviceCert, cfg.DeviceKey)
+	if len(cfg.ClientCertMQTT) > 0 { // implies the client key will also be non-empty after validation
+		keyPair, err := tls.LoadX509KeyPair(cfg.ClientCertMQTT, cfg.ClientKeyMQTT)
 		if err != nil {
-			logger.Errorf("error reading client certificate files - \"%s, %s\"", cfg.DeviceCert, cfg.DeviceKey)
-			return nil, err
+			return nil, fmt.Errorf("error reading x509 key pair files(\"%s, %s\") - %v", cfg.ClientCertMQTT, cfg.ClientKeyMQTT, err)
 		}
 		certificates = []tls.Certificate{keyPair}
 	}
-	if len(cfg.CaCert) > 0 {
-		caCert, err := ioutil.ReadFile(cfg.CaCert)
+	if len(cfg.CaCertMQTT) > 0 {
+		caCert, err := ioutil.ReadFile(cfg.CaCertMQTT)
 		if err != nil {
-			logger.Errorf("error reading CA certificate file - \"%s\"", cfg.CaCert)
-			return nil, err
+			return nil, fmt.Errorf("error reading CA certificate file \"%s\" - %v", cfg.CaCertMQTT, err)
 		}
 		caCertPool = x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
+			logger.Warningf("cannot append CA certificate loaded from \"%s\" to pool", cfg.CaCertMQTT)
+		}
 	}
 	config := &tls.Config{
 		InsecureSkipVerify: false,

--- a/client/edge.go
+++ b/client/edge.go
@@ -34,9 +34,9 @@ type BrokerConfig struct {
 	Broker   string `json:"broker,omitempty" def:"tcp://localhost:1883" descr:"Local MQTT broker address"`
 	Username string `json:"username,omitempty" descr:"Username for authorized local client"`
 	Password string `json:"password,omitempty" descr:"Password for authorized local client"`
-	CaCert   string `json:"caCert,omitempty" descr:"A PEM encoded certificate authority, used to sign the certificate of the local MQTT broker"`
-	Cert     string `json:"cert,omitempty" descr:"A PEM encoded client certificate for connection to local MQTT broker"`
-	Key      string `json:"key,omitempty" descr:"A private key for the client certificate, specified with 'cert'"`
+	CaCert   string `json:"caCert,omitempty" descr:"A PEM encoded CA certificates 'file' for MQTT broker connection"`
+	Cert     string `json:"cert,omitempty" descr:"A PEM encoded certificate 'file' for MQTT broker connection"`
+	Key      string `json:"key,omitempty" descr:"A PEM encoded unencrypted private key 'file' for MQTT broker connection"`
 }
 
 // EdgeConfiguration represents local Edge Thing configuration - its device, tenant and policy identifiers.
@@ -64,7 +64,7 @@ func NewEdgeConnector(cfg *BrokerConfig, ecl EdgeClient) (*EdgeConnector, error)
 	var tlsConfig *tls.Config
 	var certificates []tls.Certificate
 	var caCertPool *x509.CertPool
-	if len(cfg.Cert) > 0 { // implies the key will also be non-empty after validation
+	if len(cfg.Cert) > 0 || len(cfg.Key) > 0 {
 		keyPair, err := tls.LoadX509KeyPair(cfg.Cert, cfg.Key)
 		if err != nil {
 			return nil, fmt.Errorf("error reading x509 key pair files(\"%s, %s\") - %v", cfg.Cert, cfg.Key, err)

--- a/flagparse/flags.go
+++ b/flagparse/flags.go
@@ -65,7 +65,9 @@ func (cfg *UploadConfig) Validate() {
 	if cfg.Files == "" && cfg.Mode != client.ModeLax {
 		log.Fatalln("Files glob not specified. To permit unrestricted file upload set 'mode' property to 'lax'.")
 	}
-
+	if (len(cfg.ClientCertMQTT) == 0) != (len(cfg.ClientKeyMQTT) == 0) {
+		log.Fatalln("Either both client MQTT certificate and key must be set or none of them.")
+	}
 	cfg.UploadableConfig.Validate()
 }
 

--- a/flagparse/flags.go
+++ b/flagparse/flags.go
@@ -65,7 +65,7 @@ func (cfg *UploadConfig) Validate() {
 	if cfg.Files == "" && cfg.Mode != client.ModeLax {
 		log.Fatalln("Files glob not specified. To permit unrestricted file upload set 'mode' property to 'lax'.")
 	}
-	if (len(cfg.ClientCertMQTT) == 0) != (len(cfg.ClientKeyMQTT) == 0) {
+	if (len(cfg.Cert) == 0) != (len(cfg.Key) == 0) {
 		log.Fatalln("Either both client MQTT certificate and key must be set or none of them.")
 	}
 	cfg.UploadableConfig.Validate()

--- a/flagparse/testdata/testConfig.json
+++ b/flagparse/testdata/testConfig.json
@@ -20,5 +20,8 @@
   "logFileSize": 1,
   "logFileCount": 2,
   "logFileMaxAge": 3,
-  "serverCert": "testCert"
+  "serverCert": "testCert",
+  "caCert": "caCert",
+  "cert": "clientCert",
+  "key": "clientKey"
 }

--- a/uploaders/common.go
+++ b/uploaders/common.go
@@ -76,7 +76,7 @@ func NewHTTPUploader(options map[string]string, serverCert string) (Uploader, er
 
 	headers := ExtractDictionary(options, HeadersPrefix)
 
-	return &HTTPUploader{url, headers, method, serverCert, supportedCipherSuites()}, nil
+	return &HTTPUploader{url, headers, method, serverCert, SupportedCipherSuites()}, nil
 }
 
 func (u *HTTPUploader) getHTTPTransport() (*http.Transport, error) {
@@ -190,7 +190,8 @@ func ComputeMD5(f *os.File, encodeBase64 bool) (string, error) {
 	return encoded, nil
 }
 
-func supportedCipherSuites() []uint16 {
+// SupportedCipherSuites returns the ids of secure TLS cipher suites
+func SupportedCipherSuites() []uint16 {
 	cs := tls.CipherSuites()
 	cid := make([]uint16, len(cs))
 	for i := range cs {


### PR DESCRIPTION
[#5] MQTTS support in the file-upload's local connection

- added option for providing CA, used to sign MQTT broker certificate
- added option for providing device certificate/key pair for connection to MQTT broker

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>