### PR TITLE
Install to /usr/bin

### DIFF
--- a/resources/file-upload.service
+++ b/resources/file-upload.service
@@ -6,7 +6,7 @@ Requires=network.target
 Requires=mosquitto.service
 
 [Service]
-ExecStart=/usr/local/bin/file-upload -configFile /etc/file-upload/config.json
+ExecStart=/usr/bin/file-upload -configFile /etc/file-upload/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[#44] Install to /usr/bin

libostree requires all binaries installed using rpm to be in `/usr/bin` rather than `/usr/local/bin`