### PR TITLE
Change WARNING log level to WARN

### DIFF
--- a/client/uploadable.go
+++ b/client/uploadable.go
@@ -283,7 +283,7 @@ func (u *AutoUploadable) messageHandler(requestID string, msg *protocol.Envelope
 	operation := strings.TrimPrefix(msg.Path, operationPrefix)
 
 	if operation == msg.Path { //wrong prefix
-		logger.Warningf("ignoring unsupported message '%v'", msg.Topic)
+		logger.Warnf("ignoring unsupported message '%v'", msg.Topic)
 		return
 	}
 
@@ -348,7 +348,7 @@ func (u *AutoUploadable) UpdateProperty(featureID string, value interface{}) {
 func (u *AutoUploadable) uploadStatusUpdated(status *UploadStatus) {
 	defer func() {
 		if e := recover(); e != nil {
-			logger.Warning(e) //already closed
+			logger.Warn(e) //already closed
 		}
 	}()
 

--- a/client/uploads.go
+++ b/client/uploads.go
@@ -155,7 +155,7 @@ func (us *Uploads) AddMulti(correlationID string, paths []string, deleteUploaded
 		if m.totalSizeBytes != fineGrainedUploadProgressNotSupported {
 			fileInfo, err := os.Stat(path)
 			if err != nil {
-				logger.Warningf("cannot get size of file %s", path)
+				logger.Warnf("cannot get size of file %s", path)
 				m.totalSizeBytes = fineGrainedUploadProgressNotSupported // will use progress report, based on number of uploaded files
 			} else {
 				size := fileInfo.Size()
@@ -305,7 +305,7 @@ func (u *MultiUpload) changeProgress(newBytesTransferred int64) {
 	defer u.mutex.Unlock()
 	if u.totalSizeBytes == 0 { //an empty file set, nothing to change
 		if newBytesTransferred != 0 {
-			logger.Warningf("reporting non-zero transferred bytes(%d) on an empty file set", newBytesTransferred)
+			logger.Warnf("reporting non-zero transferred bytes(%d) on an empty file set", newBytesTransferred)
 		}
 	} else if u.totalSizeBytes != fineGrainedUploadProgressNotSupported {
 		u.totalBytesTransferred += newBytesTransferred
@@ -496,7 +496,7 @@ func (u *SingleUpload) start(options map[string]string) error {
 			return // unsupported
 		}
 		if u.totalSizeBytes == 0 && bytesTransferred != 0 {
-			logger.Warningf("reporting non-zero transferred bytes(%d) on an empty file(%v)", bytesTransferred, u.file)
+			logger.Warnf("reporting non-zero transferred bytes(%d) on an empty file(%v)", bytesTransferred, u.file)
 			return
 		}
 		if u.bytesTransferred != bytesTransferred {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,7 +25,7 @@ import (
 // LogConfig contains logging configuration
 type LogConfig struct {
 	LogFile       string `json:"logFile,omitempty" def:"./log/file-upload.log" descr:"Log file location in storage directory"`
-	LogLevel      string `json:"logLevel,omitempty" def:"INFO" descr:"Log levels are ERROR, WARNING, INFO, DEBUG, TRACE"`
+	LogLevel      string `json:"logLevel,omitempty" def:"INFO" descr:"Log levels are ERROR, WARN, INFO, DEBUG, TRACE"`
 	LogFileSize   int    `json:"logFileSize,omitempty" def:"2" descr:"Log file size in MB before it gets rotated"`
 	LogFileCount  int    `json:"logFileCount,omitempty" def:"5" descr:"Log file max rotations count"`
 	LogFileMaxAge int    `json:"logFileMaxAge,omitempty" def:"28" descr:"Log file rotations max age in days"`
@@ -47,7 +47,7 @@ const (
 	logFlags int = log.Ldate | log.Ltime | log.Lmicroseconds | log.Lmsgprefix
 
 	ePrefix = "ERROR  "
-	wPrefix = "WARNING"
+	wPrefix = "WARN   "
 	iPrefix = "INFO   "
 	dPrefix = "DEBUG  "
 	tPrefix = "TRACE  "
@@ -89,7 +89,7 @@ func SetupLogger(logConfig *LogConfig) (io.WriteCloser, error) {
 	switch strings.ToUpper(logConfig.LogLevel) {
 	case "INFO":
 		level = INFO
-	case "WARNING":
+	case "WARN":
 		level = WARN
 	case "DEBUG":
 		level = DEBUG
@@ -116,15 +116,15 @@ func Errorf(format string, v ...interface{}) {
 	}
 }
 
-// Warning logs the given value, if level is >= WARN
-func Warning(v interface{}) {
+// Warn logs the given value, if level is >= WARN
+func Warn(v interface{}) {
 	if level >= WARN {
 		logger.Println(wPrefix, v)
 	}
 }
 
-// Warningf logs the given formatted message, if level is >= WARN
-func Warningf(format string, v ...interface{}) {
+// Warnf logs the given formatted message, if level is >= WARN
+func Warnf(format string, v ...interface{}) {
 	if level >= WARN {
 		logger.Printf(fmt.Sprint(wPrefix, " ", format), v...)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -108,68 +108,68 @@ func validateError(log string, has bool, t *testing.T) {
 	// 1. Validate for Error function.
 	Error("error log")
 	if has != search(log, t, ePrefix, "error log") {
-		t.Errorf("error entry mishmash [result: %v]", !has)
+		t.Errorf("error entry mismatch [result: %v]", !has)
 	}
 	// 2. Validate for Errorf function.
 	Errorf("error log [%v,%s]", "param1", "param2")
 	if has != search(log, t, ePrefix, "error log [param1,param2]") {
-		t.Errorf("errorf entry mishmash: [result: %v]", !has)
+		t.Errorf("errorf entry mismatch: [result: %v]", !has)
 	}
 }
 
-// validateError validates for warn logs.
+// validateWarn validates for warn logs.
 func validateWarn(log string, has bool, t *testing.T) {
 	// 1. Validate for Warn function.
 	Warn("warn log")
 	if has != search(log, t, wPrefix, "warn log") {
-		t.Errorf("warn entry mishmash [result: %v]", !has)
+		t.Errorf("warn entry mismatch [result: %v]", !has)
 	}
 	// 2. Validate for Warnf function.
 	Warnf("warn log [%v,%s]", "param1", "param2")
 	if has != search(log, t, wPrefix, "warn log [param1,param2]") {
-		t.Errorf("warnf entry mishmash: [result: %v]", !has)
+		t.Errorf("warnf entry mismatch: [result: %v]", !has)
 	}
 }
 
-// validateError validates for info logs.
+// validateInfo validates for info logs.
 func validateInfo(log string, has bool, t *testing.T) {
 	// 1. Validate for Info function.
 	Info("info log")
 	if has != search(log, t, iPrefix, "info log") {
-		t.Errorf("info entry mishmash [result: %v]", !has)
+		t.Errorf("info entry mismatch [result: %v]", !has)
 	}
 	// 2. Validate for Infof function.
 	Infof("info log [%v,%s]", "param1", "param2")
 	if has != search(log, t, iPrefix, "info log [param1,param2]") {
-		t.Errorf("infof entry mishmash: [result: %v]", !has)
+		t.Errorf("infof entry mismatch: [result: %v]", !has)
 	}
 }
 
-// validateError validates for debug logs.
+// validateDebug validates for debug logs.
 func validateDebug(log string, has bool, t *testing.T) {
 	// 1. Validate for Debug function.
 	Debug("debug log")
 	if has != search(log, t, dPrefix, "debug log") {
-		t.Errorf("debug entry mishmash [result: %v]", !has)
+		t.Errorf("debug entry mismatch [result: %v]", !has)
 	}
 	// 2. Validate for Debugf function.
 	Debugf("debug log [%v,%s]", "param1", "param2")
 	if has != search(log, t, dPrefix, "debug log [param1,param2]") {
-		t.Errorf("debugf entry mishmash: [result: %v]", !has)
+		t.Errorf("debugf entry mismatch: [result: %v]", !has)
 	}
 }
 
-// validateError validates for trace logs.
+// validateTrace validates for trace logs.
 func validateTrace(log string, has bool, t *testing.T) {
 	// 1. Validate for Trace function.
 	Trace("trace log")
 	if has != search(log, t, tPrefix, "trace log") {
-		t.Errorf("trace entry mishmash [result: %v]", !has)
+		t.Errorf("trace entry mismatch [result: %v]", !has)
 	}
 	// 2. Validate for Tracef function.
 	Tracef("trace log [%v,%s]", "param1", "param2")
 	if has != search(log, t, tPrefix, "trace log [param1,param2]") {
-		t.Errorf("tracef entry mishmash: [result: %v]", !has)
+		t.Errorf("tracef entry mismatch: [result: %v]", !has)
 	}
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -25,9 +25,9 @@ func TestLogLevelError(t *testing.T) {
 	validate("ERROR", true, false, false, false, false, t)
 }
 
-// TestLogLevelWarning tests logger functions with log level set to WARNING.
-func TestLogLevelWarning(t *testing.T) {
-	validate("WARNING", true, true, false, false, false, t)
+// TestLogLevelWarn tests logger functions with log level set to WARN.
+func TestLogLevelWarn(t *testing.T) {
+	validate("WARN", true, true, false, false, false, t)
 }
 
 // TestLogLevelInfo tests logger functions with log level set to INFO.
@@ -54,7 +54,7 @@ func TestNopWriter(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	// Prepare the logger without writter
+	// Prepare the logger without writer
 	loggerOut, _ := SetupLogger(&LogConfig{LogFile: "", LogLevel: "TRACE", LogFileSize: 2, LogFileCount: 5})
 	defer loggerOut.Close()
 
@@ -71,7 +71,7 @@ func TestNopWriter(t *testing.T) {
 	}
 }
 
-func validate(lvl string, hasError bool, hasWarning bool, hasInfo bool, hasDebug bool, hasTrace bool, t *testing.T) {
+func validate(lvl string, hasError bool, hasWarn bool, hasInfo bool, hasDebug bool, hasTrace bool, t *testing.T) {
 	// Prepare
 	dir := "_tmp-logger"
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -90,8 +90,8 @@ func validate(lvl string, hasError bool, hasWarning bool, hasInfo bool, hasDebug
 	// 1. Validate for error logs.
 	validateError(log, hasError, t)
 
-	// 2. Validate for warning logs.
-	validateWarning(log, hasWarning, t)
+	// 2. Validate for warn logs.
+	validateWarn(log, hasWarn, t)
 
 	// 3. Validate for info logs.
 	validateInfo(log, hasInfo, t)
@@ -117,17 +117,17 @@ func validateError(log string, has bool, t *testing.T) {
 	}
 }
 
-// validateError validates for warning logs.
-func validateWarning(log string, has bool, t *testing.T) {
-	// 1. Validate for Warning function.
-	Warning("warning log")
-	if has != search(log, t, wPrefix, "warning log") {
-		t.Errorf("warning entry mishmash [result: %v]", !has)
+// validateError validates for warn logs.
+func validateWarn(log string, has bool, t *testing.T) {
+	// 1. Validate for Warn function.
+	Warn("warn log")
+	if has != search(log, t, wPrefix, "warn log") {
+		t.Errorf("warn entry mishmash [result: %v]", !has)
 	}
-	// 2. Validate for Warningf function.
-	Warningf("warning log [%v,%s]", "param1", "param2")
-	if has != search(log, t, wPrefix, "warning log [param1,param2]") {
-		t.Errorf("warningf entry mishmash: [result: %v]", !has)
+	// 2. Validate for Warnf function.
+	Warnf("warn log [%v,%s]", "param1", "param2")
+	if has != search(log, t, wPrefix, "warn log [param1,param2]") {
+		t.Errorf("warnf entry mishmash: [result: %v]", !has)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	defer loggerOut.Close()
 
 	if warn != nil {
-		logger.Warning(warn)
+		logger.Warn(warn)
 	}
 
 	logger.Infof("files glob: '%s', mode: '%s'", config.Files, config.Mode)

--- a/uploaders/aws.go
+++ b/uploaders/aws.go
@@ -59,7 +59,7 @@ func (l *awsLogger) Logf(classification logging.Classification, format string, v
 	if classification == logging.Debug {
 		logger.Debugf(format, v...)
 	} else if classification == logging.Warn {
-		logger.Warningf(format, v...)
+		logger.Warnf(format, v...)
 	} else {
 		logger.Infof(format, v...)
 	}


### PR DESCRIPTION
[#45] Change WARNING log level to WARN 
- changed function names
 - all references to the word Warning changed to Warn
 - changed configuration level property
 - some minor typo fixes

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>