### PR TITLE
Allowed default log file name to be customizable

### DIFF
--- a/flagparse/flags.go
+++ b/flagparse/flags.go
@@ -49,7 +49,7 @@ type UploadConfig struct {
 var ConfigNames = map[string]string{
 	"featureID": "AutoUploadable", "feature": "Uploadable", "period": "Upload period",
 	"action": "upload", "actions": "uploads", "running_actions": "uploads",
-	"transfers": "uploads", "logFile": "./log/file-upload.log",
+	"transfers": "uploads", "logFile": "log/file-upload.log",
 	"mode": "File access mode. Restricts which files can be requested dynamically for upload through 'upload.files' " +
 		"trigger operation property.\nAllowed values are:" +
 		"\n  'strict' - dynamically specifying files for upload is forbidden, the 'files' property must be used instead" +

--- a/flagparse/flags.go
+++ b/flagparse/flags.go
@@ -49,7 +49,7 @@ type UploadConfig struct {
 var ConfigNames = map[string]string{
 	"featureID": "AutoUploadable", "feature": "Uploadable", "period": "Upload period",
 	"action": "upload", "actions": "uploads", "running_actions": "uploads",
-	"transfers": "uploads",
+	"transfers": "uploads", "logFile": "./log/file-upload.log",
 	"mode": "File access mode. Restricts which files can be requested dynamically for upload through 'upload.files' " +
 		"trigger operation property.\nAllowed values are:" +
 		"\n  'strict' - dynamically specifying files for upload is forbidden, the 'files' property must be used instead" +

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -24,7 +24,7 @@ import (
 
 // LogConfig contains logging configuration
 type LogConfig struct {
-	LogFile       string `json:"logFile,omitempty" def:"./log/file-upload.log" descr:"Log file location in storage directory"`
+	LogFile       string `json:"logFile,omitempty" def:"{logFile}" descr:"Log file location in storage directory"`
 	LogLevel      string `json:"logLevel,omitempty" def:"INFO" descr:"Log levels are ERROR, WARN, INFO, DEBUG, TRACE"`
 	LogFileSize   int    `json:"logFileSize,omitempty" def:"2" descr:"Log file size in MB before it gets rotated"`
 	LogFileCount  int    `json:"logFileCount,omitempty" def:"5" descr:"Log file max rotations count"`
@@ -61,7 +61,7 @@ var (
 )
 
 // SetupLogger initializes logger with the provided configuration
-func SetupLogger(logConfig *LogConfig) (io.WriteCloser, error) {
+func SetupLogger(logConfig *LogConfig, componentPrefix string) (io.WriteCloser, error) {
 	loggerOut := io.WriteCloser(&nopWriterCloser{out: os.Stderr})
 	if len(logConfig.LogFile) > 0 {
 		err := os.MkdirAll(filepath.Dir(logConfig.LogFile), 0755)
@@ -83,7 +83,7 @@ func SetupLogger(logConfig *LogConfig) (io.WriteCloser, error) {
 	log.SetOutput(loggerOut)
 	log.SetFlags(logFlags)
 
-	logger = log.New(loggerOut, fmt.Sprintf(prefix, "[FILE UPLOAD]"), logFlags)
+	logger = log.New(loggerOut, fmt.Sprintf(prefix, componentPrefix), logFlags)
 
 	// Parse log level
 	switch strings.ToUpper(logConfig.LogLevel) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -52,7 +52,7 @@ const (
 	dPrefix = "DEBUG  "
 	tPrefix = "TRACE  "
 
-	prefix = " %-10s"
+	prefix = " %s "
 )
 
 var (

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -55,7 +55,7 @@ func TestNopWriter(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Prepare the logger without writer
-	loggerOut, _ := SetupLogger(&LogConfig{LogFile: "", LogLevel: "TRACE", LogFileSize: 2, LogFileCount: 5}, "[FILE UPLOAD] ")
+	loggerOut, _ := SetupLogger(&LogConfig{LogFile: "", LogLevel: "TRACE", LogFileSize: 2, LogFileCount: 5}, "[FILE UPLOAD]")
 	defer loggerOut.Close()
 
 	// Validate that temporary is empty
@@ -81,7 +81,7 @@ func validate(lvl string, hasError bool, hasWarn bool, hasInfo bool, hasDebug bo
 
 	// Prepare the logger
 	log := filepath.Join(dir, lvl+".log")
-	loggerOut, err := SetupLogger(&LogConfig{LogFile: log, LogLevel: lvl, LogFileSize: 2, LogFileCount: 5}, "[FILE UPLOAD] ")
+	loggerOut, err := SetupLogger(&LogConfig{LogFile: log, LogLevel: lvl, LogFileSize: 2, LogFileCount: 5}, "[FILE UPLOAD]")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -55,7 +55,7 @@ func TestNopWriter(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Prepare the logger without writer
-	loggerOut, _ := SetupLogger(&LogConfig{LogFile: "", LogLevel: "TRACE", LogFileSize: 2, LogFileCount: 5})
+	loggerOut, _ := SetupLogger(&LogConfig{LogFile: "", LogLevel: "TRACE", LogFileSize: 2, LogFileCount: 5}, "[FILE UPLOAD] ")
 	defer loggerOut.Close()
 
 	// Validate that temporary is empty
@@ -81,7 +81,7 @@ func validate(lvl string, hasError bool, hasWarn bool, hasInfo bool, hasDebug bo
 
 	// Prepare the logger
 	log := filepath.Join(dir, lvl+".log")
-	loggerOut, err := SetupLogger(&LogConfig{LogFile: log, LogLevel: lvl, LogFileSize: 2, LogFileCount: 5})
+	loggerOut, err := SetupLogger(&LogConfig{LogFile: log, LogLevel: lvl, LogFileSize: 2, LogFileCount: 5}, "[FILE UPLOAD] ")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	config, warn := flags.ParseFlags(version)
 
 	config.Validate()
-	loggerOut, err := logger.SetupLogger(&config.LogConfig, "[FILE UPLOAD] ")
+	loggerOut, err := logger.SetupLogger(&config.LogConfig, "[FILE UPLOAD]")
 	if err != nil {
 		log.Fatalln("Failed to initialize logger: ", err)
 	}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	config, warn := flags.ParseFlags(version)
 
 	config.Validate()
-	loggerOut, err := logger.SetupLogger(&config.LogConfig)
+	loggerOut, err := logger.SetupLogger(&config.LogConfig, "[FILE UPLOAD] ")
 	if err != nil {
 		log.Fatalln("Failed to initialize logger: ", err)
 	}


### PR DESCRIPTION
[#50] Allow default log file name to be customizable
 - Allowed default log file name to be specified with a customizable string
 - Extended logger setup to allow for a customizable logger name prefix

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>