### PR TITLE
HTTP storage provider is created with wrong argument

### DIFF
--- a/integration/upload_test_util.go
+++ b/integration/upload_test_util.go
@@ -46,7 +46,7 @@ func (suite *FileUploadSuite) SetupStorageProvider(provider Provider) {
 		if len(suite.uploadCfg.HTTPServer) == 0 {
 			suite.T().Fatal("http server must be set")
 		}
-		suite.provider = newHTTPStorageProvider(suite.T(), suite.uploadCfg.UploadDir)
+		suite.provider = newHTTPStorageProvider(suite.T(), suite.uploadCfg.HTTPServer)
 	default:
 		suite.T().Fatalf("storage provider %d not defined", provider)
 	}


### PR DESCRIPTION
[#76] HTTP storage provider is created with wrong argument

- fixed

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>