### PR TITLE
uploadTestConfig and uploadCfg from FileUploadSuite should be e…

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -25,7 +25,7 @@ type FileUploadSuite struct {
 	ThingURL   string
 	FeatureURL string
 
-	uploadCfg uploadTestConfig
+	UploadCfg UploadTestConfig
 	provider  storageProvider
 }
 
@@ -41,8 +41,8 @@ type awsFileUploadSuite struct {
 	FileUploadSuite
 }
 
-// uploadTestConfig contains the test configuration data, such as upload directory and http server URL
-type uploadTestConfig struct {
+// UploadTestConfig contains the test configuration data, such as upload directory and http server URL
+type UploadTestConfig struct {
 	UploadDir  string `env:"FUT_UPLOAD_DIR"`
 	HTTPServer string `env:"FUT_HTTP_SERVER"`
 }

--- a/integration/upload_test.go
+++ b/integration/upload_test.go
@@ -28,10 +28,10 @@ func (suite *FileUploadSuite) SetupSuite() {
 	suite.Setup(suite.T())
 
 	opts := env.Options{RequiredIfNoDef: false}
-	suite.uploadCfg = uploadTestConfig{}
-	require.NoError(suite.T(), env.Parse(&suite.uploadCfg, opts), "failed to process upload environment variables")
-	suite.T().Logf("upload test configuration - %v", suite.uploadCfg)
-	suite.AssertEmptyDir(suite.uploadCfg.UploadDir)
+	suite.UploadCfg = UploadTestConfig{}
+	require.NoError(suite.T(), env.Parse(&suite.UploadCfg, opts), "failed to process upload environment variables")
+	suite.T().Logf("upload test configuration - %v", suite.UploadCfg)
+	suite.AssertEmptyDir(suite.UploadCfg.UploadDir)
 
 	suite.ThingURL = util.GetThingURL(suite.Cfg.DigitalTwinAPIAddress, suite.ThingCfg.DeviceID)
 	suite.FeatureURL = util.GetFeatureURL(suite.ThingURL, featureID)
@@ -87,8 +87,8 @@ func (suite *FileUploadSuite) checkUploadedFiles(requestedFiles map[string]strin
 }
 
 func (suite *FileUploadSuite) testUpload() {
-	files, err := CreateTestFiles(suite.uploadCfg.UploadDir, uploadFilesCount)
-	defer suite.RemoveFilesSilently(suite.uploadCfg.UploadDir)
+	files, err := CreateTestFiles(suite.UploadCfg.UploadDir, uploadFilesCount)
+	defer suite.RemoveFilesSilently(suite.UploadCfg.UploadDir)
 	require.NoError(suite.T(), err, "creating test files failed")
 
 	requestedFiles := suite.UploadRequests(featureID, operationTrigger, nil, uploadFilesCount)

--- a/integration/upload_test_util.go
+++ b/integration/upload_test_util.go
@@ -43,10 +43,10 @@ func (suite *FileUploadSuite) SetupStorageProvider(provider Provider) {
 	case AzureStorageProvider:
 		suite.provider = newAzureStorageProvider(suite.T())
 	case GenericStorageProvider:
-		if len(suite.uploadCfg.HTTPServer) == 0 {
+		if len(suite.UploadCfg.HTTPServer) == 0 {
 			suite.T().Fatal("http server must be set")
 		}
-		suite.provider = newHTTPStorageProvider(suite.T(), suite.uploadCfg.HTTPServer)
+		suite.provider = newHTTPStorageProvider(suite.T(), suite.UploadCfg.HTTPServer)
 	default:
 		suite.T().Fatalf("storage provider %d not defined", provider)
 	}


### PR DESCRIPTION
[#78] uploadTestConfig and uploadCfg from FileUploadSuite should be exported by file upload integration test

- fixed

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>