### PR TITLE
Check if HTTPS tests using system cert pool can be ran on Windows(and possibly Mac OS X)

### DIFF
--- a/uploaders/common_test.go
+++ b/uploaders/common_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
@@ -160,9 +159,6 @@ func isCertAddedToSystemPool(t *testing.T, certFile string) bool {
 func setSSLCerts(t *testing.T) {
 	t.Helper()
 
-	if runtime.GOOS != "linux" {
-		t.Skip("this test only runs on Linux.")
-	}
 	sslCertFile = os.Getenv(sslCertFileEnv)
 	err := os.Setenv(sslCertFileEnv, validCert)
 	if err != nil {


### PR DESCRIPTION
[#83] Check if HTTPS tests using system cert pool can be ran on Windows(and possibly Mac OS X)

- test is now skipped, instead of error(at least on Windows 10), will wait upgrading to newer go versions(1.20.x) to test the new API to add certificates